### PR TITLE
Fix NEW: prefix on plugin/patch menu items

### DIFF
--- a/modules/profiles.lua
+++ b/modules/profiles.lua
@@ -120,6 +120,15 @@ return function(MenuDisabler)
                 if data.fm then local f=io.open(f1,"w"); f:write(data.fm); f:close() else os.remove(f1) end
                 local f2 = self.settings_path.."/reader_menu_order.lua"
                 if data.reader then local f=io.open(f2,"w"); f:write(data.reader); f:close() else os.remove(f2) end
+                -- Re-merge discovered plugin/patch items into the restored profile files
+                if data.fm then
+                    local working = self:generateWorkingList("filemanager", "filemanager_menu_order.lua")
+                    self:writeOrderFile("filemanager", "filemanager_menu_order.lua", working.enabled_map)
+                end
+                if data.reader then
+                    local working = self:generateWorkingList("reader", "reader_menu_order.lua")
+                    self:writeOrderFile("reader", "reader_menu_order.lua", working.enabled_map)
+                end
                 self:safeRestart()
             end
         })


### PR DESCRIPTION
**Issue:**
KOReader's MenuSorter marks menu items as "NEW:" when they appear at runtime but aren't listed in the saved menu order config file. Since Menu Disabler only writes system default items to its config, any items registered by plugins or patches end up "orphaned", so they get the "NEW:" prefix after every restart.

**Fix:**
backend.lua:
 * `getAvailablePlugins()` now also scans `./patches/` for menu items, not just `./plugins/`. Patches use a variety of patterns to register items (dot notation, bracket notation, `table.insert` into order tables, variable indirection via local functions), so the scanner handles all five styles. It also extracts the target menu section from `MenuOrder.section_name` references in each patch file.
 * `generateWorkingList()` has two new steps before applying the disabled list:
   * Step 2A imports items from the user's existing saved config that aren't in system defaults (preserves plugin items from a previous save).
    * Step 2B imports newly discovered plugin/patch items into the correct section based on `sorting_hint`, and relocates items that were previously stuck in `more_tools` when a better section is now known.
 * Extracted file-writing logic into a new `writeOrderFile()` helper so it can be reused. `saveChanges()` now calls this helper.

profiles.lua:
 * `applyProfile()` re-merges discovered plugin/patch items after restoring a profile's raw config, so loading an old profile doesn't bring back the "NEW:" prefix.

Note: this code was written with assistance from Claude (especially the regex/match syntax 😵‍💫)